### PR TITLE
address delayed release

### DIFF
--- a/db/models/models.rb
+++ b/db/models/models.rb
@@ -4,11 +4,15 @@ module EGS
       many_to_one :release
 
       def eql?(other)
-        self.title == other.title && self.start_date == other.start_date
+        self.title == other.title &&
+          self.start_date == other.start_date &&
+          self.end_date == other.end_date
       end
 
       def hash
-        self.title.hash ^ self.start_date.hash
+        self.title.hash ^
+          self.start_date.hash ^
+          self.end_date.hash
       end
 
       def <=>(other)

--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -20,14 +20,15 @@ module EGS
         return LOG.info('No games! Skipping...') if new_games.empty?
 
         current_games = current_release.free_games
-        latest_new_game = new_games.sort.last
+
         if current_games == new_games
-          current_release.update(end_date: latest_new_game.end_date)
-          LOG.info('Games from OLD in NEW Release! Updating OLD Release end date!')
+          LOG.info('Games from OLD in NEW Release! Data for NEW Release is probably delayed!')
         else
+          latest_new_game = new_games.sort.last
           new_release = Models::Release.create(
             start_date: latest_new_game.start_date,
-            end_date: latest_new_game.end_date)
+            end_date: latest_new_game.end_date
+          )
           new_games.each do |game|
             game.release_id = new_release.id
             game.save
@@ -40,8 +41,8 @@ module EGS
 
       def wait
         time_left = Models::Release.last.time_left
-        that_many_seconds = time_left.positive? ? time_left + ENV['DELAY_SEC'].to_i : ENV['TIMEOUT_SEC'].to_i
-        LOG.info "Sleeping: #{convert_to_human_readable(that_many_seconds)} ..."
+        that_many_seconds = time_left.positive? ? time_left : ENV['TIMEOUT_SEC'].to_i
+        LOG.info "Waiting: #{convert_to_human_readable(that_many_seconds)} ..."
         sleep that_many_seconds
       end
     end


### PR DESCRIPTION
* EGS do not push out updates on a new release in exact time sometimes.

  Do not update the old release end_date, if the games from the previous release are the same as the ones from new one. It is probably the old data.

  If they are all the same except the end_date, make it a new release.
  
  Fixes #15 